### PR TITLE
Noticed a mismatch between default config and documentation wrt bridge-mappings

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -48,7 +48,7 @@ options:
       within an OpenStack cloud.
   bridge-mappings:
     type: string
-    default: 'physnet1:br-data'
+    default: 'physnet1:br-ex'
     description: |
       Space-delimited list of ML2 data bridge mappings with format
       <provider>:<bridge>.


### PR DESCRIPTION
While deploying the bundle/openstack I noticed that my base install where not able to access any 'provider' network, on investigation I noticed that the charms had different physnet1:X mappings; neutron-openvswitch used br-data while the others used br-ex, this caused the openvwitch to tie to br-data, that was not tied to a physical interface. On investigation I noticed that the example/documentation for this charm also seemed to reference br-ex as the basic example (br-data used in multiple physical mappings). 