### PR TITLE
Fixes for OVS-DPDK

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -37,6 +37,15 @@ options:
       Port can also be a linuxbridge bridge. In this case a veth pair will be
       created, the ovs bridge and the linuxbridge bridge will be connected. It
       can be useful to connect the ovs bridge to juju bridge.
+  bond-mappings:
+    type: string
+    default:
+    description: |
+      Space-delimited list of bond:port mappings. Ports will be added to their
+      corresponding bond, which in turn will be put into the bridge as
+      specified in data-port.
+      .
+      This option is supported only when enable-dpdk is true.
   disable-security-groups:
     type: boolean
     default: false

--- a/config.yaml
+++ b/config.yaml
@@ -151,6 +151,7 @@ options:
       .
         vfio-pci
         uio_pci_generic
+        none
       .
       Only used when DPDK is enabled.
   enable-sriov:

--- a/hooks/charmhelpers/contrib/network/ovs/__init__.py
+++ b/hooks/charmhelpers/contrib/network/ovs/__init__.py
@@ -134,6 +134,16 @@ def set_manager(manager):
                            'ssl:{}'.format(manager)])
 
 
+def set_value(table, arg1, arg2):
+    ''' Set the controller for the local openvswitch '''
+    log('Setting table {} {} {}'.format(table, arg1, arg2))
+    subprocess.check_call(['ovs-vsctl', 'set', table, arg1, arg2])
+
+
+def set_value_Open_vSwitch(arg):
+    return set_value('Open_vSwitch', '.', arg)
+
+
 CERT_PATH = '/etc/openvswitch/ovsclient-cert.pem'
 
 

--- a/hooks/neutron_ovs_context.py
+++ b/hooks/neutron_ovs_context.py
@@ -301,8 +301,11 @@ def numa_node_cores():
 class DPDKDeviceContext(OSContextGenerator):
 
     def __call__(self):
+        driver = config('dpdk-driver')
+        if driver == 'none':
+            return {}
         return {'devices': resolve_dpdk_ports(),
-                'driver': config('dpdk-driver')}
+                'driver': driver}
 
 
 class OVSDPDKDeviceContext(OSContextGenerator):

--- a/hooks/neutron_ovs_context.py
+++ b/hooks/neutron_ovs_context.py
@@ -240,7 +240,7 @@ class L3AgentContext(OSContextGenerator):
         return ctxt
 
 
-def resolve_dpdk_ports():
+def resolve_dpdk_bridges():
     '''
     Resolve local PCI devices from configured mac addresses
     using the data-port configuration option
@@ -265,6 +265,35 @@ def resolve_dpdk_ports():
             pci_address = db.get(mac)
             if pci_address:
                 resolved_devices[pci_address] = bridge
+
+    return resolved_devices
+
+
+def resolve_dpdk_bonds():
+    '''
+    Resolve local PCI devices from configured mac addresses
+    using the data-port configuration option
+
+    @return: OrderDict indexed by PCI device address.
+    '''
+    bonds = config('bond-mappings')
+    devices = PCINetDevices()
+    resolved_devices = collections.OrderedDict()
+    db = kv()
+    if bonds:
+        # NOTE: ordered dict of format {[mac]: bond}
+        bondmap = parse_data_port_mappings(bonds)
+        for mac, bond in bondmap.items():
+            pcidev = devices.get_device_from_mac(mac)
+            if pcidev:
+                # NOTE: store mac->pci allocation as post binding
+                #       to dpdk, it disappears from PCIDevices.
+                db.set(mac, pcidev.pci_address)
+                db.flush()
+
+            pci_address = db.get(mac)
+            if pci_address:
+                resolved_devices[pci_address] = bond
 
     return resolved_devices
 
@@ -304,7 +333,7 @@ class DPDKDeviceContext(OSContextGenerator):
         driver = config('dpdk-driver')
         if driver == 'none':
             return {}
-        return {'devices': resolve_dpdk_ports(),
+        return {'devices': resolve_dpdk_bridges(),
                 'driver': driver}
 
 
@@ -340,7 +369,7 @@ class OVSDPDKDeviceContext(OSContextGenerator):
         '''Formatted list of devices to whitelist for dpdk'''
         _flag = '-w {device}'
         whitelist = []
-        for device in resolve_dpdk_ports():
+        for device in resolve_dpdk_bridges():
             whitelist.append(_flag.format(device=device))
         return ' '.join(whitelist)
 

--- a/hooks/neutron_ovs_utils.py
+++ b/hooks/neutron_ovs_utils.py
@@ -40,6 +40,7 @@ from charmhelpers.contrib.network.ovs import (
     full_restart,
     enable_ipfix,
     disable_ipfix,
+    set_value_Open_vSwitch
 )
 from charmhelpers.core.hookenv import (
     config,
@@ -69,6 +70,7 @@ from charmhelpers.fetch import (
     apt_purge,
     apt_update,
     filter_installed_packages,
+    get_upstream_version
 )
 
 from pci import PCINetDevices
@@ -307,6 +309,8 @@ def resource_map():
         )
         if not use_dpdk():
             drop_config.append(DPDK_INTERFACES)
+        if ovs_has_late_dpdk_init():
+            drop_config.append(OVS_CONF)
     else:
         drop_config.extend([OVS_CONF, DPDK_INTERFACES])
 
@@ -376,6 +380,17 @@ OVS_DEFAULT_BIN = '/usr/lib/openvswitch-switch/ovs-vswitchd'
 def enable_ovs_dpdk():
     '''Enables the DPDK variant of ovs-vswitchd and restarts it'''
     subprocess.check_call(UPDATE_ALTERNATIVES + [OVS_DPDK_BIN])
+    if ovs_has_late_dpdk_init():
+        ctxt = neutron_ovs_context.OVSDPDKDeviceContext()
+        set_value_Open_vSwitch(
+            'other_config:dpdk-init=true')
+        set_value_Open_vSwitch(
+            'other_config:dpdk-lcore-mask={}'.format(ctxt['cpu_mask']))
+        set_value_Open_vSwitch(
+            'other_config:dpdk-socket-mem={}'.format(ctxt['socket_memory']))
+        set_value_Open_vSwitch(
+            'other_config:dpdk-extra=--vhost-owner'
+            ' libvirt-qemu:kvm --vhost-perm 0660')
     if not is_unit_paused_set():
         service_restart('openvswitch-switch')
 
@@ -410,12 +425,12 @@ def configure_ovs():
     else:
         # NOTE: when in dpdk mode, add based on pci bus order
         #       with type 'dpdk'
-        dpdk_bridgemaps = neutron_ovs_context.resolve_dpdk_ports()
+        bridgemaps = neutron_ovs_context.resolve_dpdk_ports()
         device_index = 0
-        for br in dpdk_bridgemaps.values():
+        for pci_address, br in bridgemaps.items():
             add_bridge(br, datapath_type)
             dpdk_add_bridge_port(br, 'dpdk{}'.format(device_index),
-                                 port_type='dpdk')
+                                 pci_address)
             device_index += 1
 
     target = config('ipfix-target')
@@ -558,6 +573,12 @@ def use_dpdk():
     return (cmp_release >= 'mitaka' and config('enable-dpdk'))
 
 
+def ovs_has_late_dpdk_init():
+    ''' OVS 2.6.0 introduces late initialization '''
+    ovs_version = get_upstream_version("openvswitch-switch")
+    return ovs_version >= '2.6.0'
+
+
 def enable_sriov():
     '''Determine whether SR-IOV is enabled and supported'''
     cmp_release = CompareOpenStackReleases(
@@ -566,13 +587,19 @@ def enable_sriov():
 
 
 # TODO: update into charm-helpers to add port_type parameter
-def dpdk_add_bridge_port(name, port, promisc=False, port_type=None):
+def dpdk_add_bridge_port(name, port, pci_address=None):
     ''' Add a port to the named openvswitch bridge '''
     # log('Adding port {} to bridge {}'.format(port, name))
-    cmd = ["ovs-vsctl", "--", "--may-exist", "add-port", name, port]
-    if port_type:
-        cmd += ['--', 'set', 'Interface', port,
-                'type={}'.format(port_type)]
+    if ovs_has_late_dpdk_init():
+        cmd = ["ovs-vsctl",
+               "add-port", name, port, "--",
+               "set", "Interface", port,
+               "type=dpdk",
+               "options:dpdk-devargs={}".format(pci_address)]
+    else:
+        cmd = ["ovs-vsctl", "--",
+               "--may-exist", "add-port", name, port,
+               "--", "set", "Interface", port, "type=dpdk"]
     subprocess.check_call(cmd)
 
 

--- a/unit_tests/test_neutron_ovs_context.py
+++ b/unit_tests/test_neutron_ovs_context.py
@@ -644,6 +644,15 @@ class TestDPDKDeviceContext(CharmTestCase):
         })
         self.config.assert_called_with('dpdk-driver')
 
+    def test_context_none_driver(self):
+        self.test_config.set('dpdk-driver', 'none')
+        self.resolve_dpdk_bridges.return_value = [
+            '0000:00:1c.0',
+            '0000:00:1d.0'
+        ]
+        self.assertEqual(self.test_context(), {})
+        self.config.assert_called_with('dpdk-driver')
+
 
 class TestRemoteRestartContext(CharmTestCase):
 

--- a/unit_tests/test_neutron_ovs_context.py
+++ b/unit_tests/test_neutron_ovs_context.py
@@ -501,6 +501,11 @@ DPDK_DATA_PORTS = (
     "br-phynet1:fe:16:41:df:23:fd "
     "br-phynet2:fe:f2:d0:45:dc:66"
 )
+BOND_MAPPINGS = (
+    "bond0:fe:16:41:df:23:fe "
+    "bond0:fe:16:41:df:23:fd "
+    "bond1:fe:f2:d0:45:dc:66"
+)
 PCI_DEVICE_MAP = {
     'fe:16:41:df:23:fd': MockPCIDevice('0000:00:1c.0'),
     'fe:16:41:df:23:fe': MockPCIDevice('0000:00:1d.0'),
@@ -534,20 +539,29 @@ class TestDPDKUtils(CharmTestCase):
         self.glob.glob.assert_called_with('/sys/devices/system/node/node*')
         _parse_cpu_list.assert_called_with(TEST_CPULIST_1)
 
-    def test_resolve_dpdk_ports(self):
+    def test_resolve_dpdk_bridges(self):
         self.test_config.set('data-port', DPDK_DATA_PORTS)
         _pci_devices = Mock()
         _pci_devices.get_device_from_mac.side_effect = PCI_DEVICE_MAP.get
         self.PCINetDevices.return_value = _pci_devices
-        self.assertEqual(context.resolve_dpdk_ports(),
+        self.assertEqual(context.resolve_dpdk_bridges(),
                          {'0000:00:1c.0': 'br-phynet1',
                           '0000:00:1d.0': 'br-phynet3'})
+
+    def test_resolve_dpdk_bonds(self):
+        self.test_config.set('bond-mappings', BOND_MAPPINGS)
+        _pci_devices = Mock()
+        _pci_devices.get_device_from_mac.side_effect = PCI_DEVICE_MAP.get
+        self.PCINetDevices.return_value = _pci_devices
+        self.assertEqual(context.resolve_dpdk_bonds(),
+                         {'0000:00:1c.0': 'bond0',
+                          '0000:00:1d.0': 'bond0'})
 
 
 DPDK_PATCH = [
     'parse_cpu_list',
     'numa_node_cores',
-    'resolve_dpdk_ports',
+    'resolve_dpdk_bridges',
     'glob',
 ]
 
@@ -572,7 +586,7 @@ class TestOVSDPDKDeviceContext(CharmTestCase):
 
     def test_device_whitelist(self):
         '''Test device whitelist generation'''
-        self.resolve_dpdk_ports.return_value = [
+        self.resolve_dpdk_bridges.return_value = [
             '0000:00:1c.0',
             '0000:00:1d.0'
         ]
@@ -606,12 +620,12 @@ class TestOVSDPDKDeviceContext(CharmTestCase):
 
     def test_context_no_devices(self):
         '''Ensure that DPDK is disable when no devices detected'''
-        self.resolve_dpdk_ports.return_value = []
+        self.resolve_dpdk_bridges.return_value = []
         self.assertEqual(self.test_context(), {})
 
     def test_context_devices(self):
         '''Ensure DPDK is enabled when devices are detected'''
-        self.resolve_dpdk_ports.return_value = [
+        self.resolve_dpdk_bridges.return_value = [
             '0000:00:1c.0',
             '0000:00:1d.0'
         ]
@@ -634,7 +648,7 @@ class TestDPDKDeviceContext(CharmTestCase):
         self.test_context = context.DPDKDeviceContext()
 
     def test_context(self):
-        self.resolve_dpdk_ports.return_value = [
+        self.resolve_dpdk_bridges.return_value = [
             '0000:00:1c.0',
             '0000:00:1d.0'
         ]

--- a/unit_tests/test_neutron_ovs_utils.py
+++ b/unit_tests/test_neutron_ovs_utils.py
@@ -55,6 +55,7 @@ TO_PATCH = [
     'PCINetDevices',
     'enable_ipfix',
     'disable_ipfix',
+    'ovs_has_late_dpdk_init',
 ]
 
 head_pkg = 'linux-headers-3.15.0-5-generic'
@@ -92,6 +93,7 @@ class TestNeutronOVSUtils(CharmTestCase):
         self.neutron_plugin_attribute.side_effect = _mock_npa
         self.config.side_effect = self.test_config.get
         self.use_dpdk.return_value = False
+        self.ovs_has_late_dpdk_init.return_value = False
 
     def tearDown(self):
         # Reset cached cache
@@ -470,11 +472,8 @@ class TestNeutronOVSUtils(CharmTestCase):
         ])
         self.add_bridge_port.assert_called_with('br-ex', 'eth0')
 
-    @patch.object(neutron_ovs_context, 'resolve_dpdk_ports')
-    @patch.object(nutils, 'use_dvr')
-    @patch('charmhelpers.contrib.openstack.context.config')
-    def test_configure_ovs_dpdk(self, mock_config, _use_dvr,
-                                _resolve_dpdk_ports):
+    def _run_configure_ovs_dpdk(self, mock_config, _use_dvr,
+                                _resolve_dpdk_ports, _late_init):
         _resolve_dpdk_ports.return_value = OrderedDict([
             ('0000:001c.01', 'br-phynet1'),
             ('0000:001c.02', 'br-phynet2'),
@@ -482,6 +481,7 @@ class TestNeutronOVSUtils(CharmTestCase):
         ])
         _use_dvr.return_value = True
         self.use_dpdk.return_value = True
+        self.ovs_has_late_dpdk_init.return_value = _late_init
         mock_config.side_effect = self.test_config.get
         self.config.side_effect = self.test_config.get
         self.test_config.set('enable-dpdk', True)
@@ -495,11 +495,27 @@ class TestNeutronOVSUtils(CharmTestCase):
             any_order=True
         )
         self.dpdk_add_bridge_port.assert_has_calls([
-            call('br-phynet1', 'dpdk0', port_type='dpdk'),
-            call('br-phynet2', 'dpdk1', port_type='dpdk'),
-            call('br-phynet3', 'dpdk2', port_type='dpdk')],
+            call('br-phynet1', 'dpdk0', '0000:001c.01'),
+            call('br-phynet2', 'dpdk1', '0000:001c.02'),
+            call('br-phynet3', 'dpdk2', '0000:001c.03')],
             any_order=True
         )
+
+    @patch.object(neutron_ovs_context, 'resolve_dpdk_ports')
+    @patch.object(nutils, 'use_dvr')
+    @patch('charmhelpers.contrib.openstack.context.config')
+    def test_configure_ovs_dpdk(self, mock_config, _use_dvr,
+                                _resolve_dpdk_ports):
+        return self._run_configure_ovs_dpdk(mock_config, _use_dvr,
+                                            _resolve_dpdk_ports, False)
+
+    @patch.object(neutron_ovs_context, 'resolve_dpdk_ports')
+    @patch.object(nutils, 'use_dvr')
+    @patch('charmhelpers.contrib.openstack.context.config')
+    def test_configure_ovs_dpdk_late_init(self, mock_config, _use_dvr,
+                                          _resolve_dpdk_ports):
+        return self._run_configure_ovs_dpdk(mock_config, _use_dvr,
+                                            _resolve_dpdk_ports, True)
 
     @patch('charmhelpers.contrib.openstack.context.config')
     def test_configure_ovs_enable_ipfix(self, mock_config):

--- a/unit_tests/test_neutron_ovs_utils.py
+++ b/unit_tests/test_neutron_ovs_utils.py
@@ -34,6 +34,7 @@ TO_PATCH = [
     'add_ovsbridge_linuxbridge',
     'is_linuxbridge_interface',
     'dpdk_add_bridge_port',
+    'dpdk_add_bridge_bond',
     'apt_install',
     'apt_update',
     'config',
@@ -473,12 +474,21 @@ class TestNeutronOVSUtils(CharmTestCase):
         self.add_bridge_port.assert_called_with('br-ex', 'eth0')
 
     def _run_configure_ovs_dpdk(self, mock_config, _use_dvr,
-                                _resolve_dpdk_ports, _late_init):
-        _resolve_dpdk_ports.return_value = OrderedDict([
+                                _resolve_dpdk_bridges, _resolve_dpdk_bonds,
+                                _late_init, _test_bonds):
+        _resolve_dpdk_bridges.return_value = OrderedDict([
             ('0000:001c.01', 'br-phynet1'),
             ('0000:001c.02', 'br-phynet2'),
             ('0000:001c.03', 'br-phynet3'),
         ])
+        if _test_bonds:
+            _resolve_dpdk_bonds.return_value = OrderedDict([
+                ('0000:001c.01', 'bond0'),
+                ('0000:001c.02', 'bond1'),
+                ('0000:001c.03', 'bond2'),
+            ])
+        else:
+            _resolve_dpdk_bonds.return_value = OrderedDict()
         _use_dvr.return_value = True
         self.use_dpdk.return_value = True
         self.ovs_has_late_dpdk_init.return_value = _late_init
@@ -494,28 +504,59 @@ class TestNeutronOVSUtils(CharmTestCase):
             call('br-phynet3', 'netdev')],
             any_order=True
         )
-        self.dpdk_add_bridge_port.assert_has_calls([
-            call('br-phynet1', 'dpdk0', '0000:001c.01'),
-            call('br-phynet2', 'dpdk1', '0000:001c.02'),
-            call('br-phynet3', 'dpdk2', '0000:001c.03')],
-            any_order=True
-        )
+        if _test_bonds:
+            self.dpdk_add_bridge_bond.assert_has_calls([
+                call('br-phynet1', 'bond0', ['dpdk0'], ['0000:001c.01']),
+                call('br-phynet2', 'bond1', ['dpdk1'], ['0000:001c.02']),
+                call('br-phynet3', 'bond2', ['dpdk2'], ['0000:001c.03'])],
+                any_order=True
+            )
+        else:
+            self.dpdk_add_bridge_port.assert_has_calls([
+                call('br-phynet1', 'dpdk0', '0000:001c.01'),
+                call('br-phynet2', 'dpdk1', '0000:001c.02'),
+                call('br-phynet3', 'dpdk2', '0000:001c.03')],
+                any_order=True
+            )
 
-    @patch.object(neutron_ovs_context, 'resolve_dpdk_ports')
+    @patch.object(neutron_ovs_context, 'resolve_dpdk_bonds')
+    @patch.object(neutron_ovs_context, 'resolve_dpdk_bridges')
     @patch.object(nutils, 'use_dvr')
     @patch('charmhelpers.contrib.openstack.context.config')
     def test_configure_ovs_dpdk(self, mock_config, _use_dvr,
-                                _resolve_dpdk_ports):
+                                _resolve_dpdk_bridges,
+                                _resolve_dpdk_bonds):
         return self._run_configure_ovs_dpdk(mock_config, _use_dvr,
-                                            _resolve_dpdk_ports, False)
+                                            _resolve_dpdk_bridges,
+                                            _resolve_dpdk_bonds,
+                                            _late_init=False,
+                                            _test_bonds=False)
 
-    @patch.object(neutron_ovs_context, 'resolve_dpdk_ports')
+    @patch.object(neutron_ovs_context, 'resolve_dpdk_bonds')
+    @patch.object(neutron_ovs_context, 'resolve_dpdk_bridges')
     @patch.object(nutils, 'use_dvr')
     @patch('charmhelpers.contrib.openstack.context.config')
     def test_configure_ovs_dpdk_late_init(self, mock_config, _use_dvr,
-                                          _resolve_dpdk_ports):
+                                          _resolve_dpdk_bridges,
+                                          _resolve_dpdk_bonds):
         return self._run_configure_ovs_dpdk(mock_config, _use_dvr,
-                                            _resolve_dpdk_ports, True)
+                                            _resolve_dpdk_bridges,
+                                            _resolve_dpdk_bonds,
+                                            _late_init=True,
+                                            _test_bonds=False)
+
+    @patch.object(neutron_ovs_context, 'resolve_dpdk_bonds')
+    @patch.object(neutron_ovs_context, 'resolve_dpdk_bridges')
+    @patch.object(nutils, 'use_dvr')
+    @patch('charmhelpers.contrib.openstack.context.config')
+    def test_configure_ovs_dpdk_late_init_bonds(self, mock_config, _use_dvr,
+                                                _resolve_dpdk_bridges,
+                                                _resolve_dpdk_bonds):
+        return self._run_configure_ovs_dpdk(mock_config, _use_dvr,
+                                            _resolve_dpdk_bridges,
+                                            _resolve_dpdk_bonds,
+                                            _late_init=True,
+                                            _test_bonds=True)
 
     @patch('charmhelpers.contrib.openstack.context.config')
     def test_configure_ovs_enable_ipfix(self, mock_config):


### PR DESCRIPTION
This patchseries contains 3 patches :

 * ovs-dpdk: allow dpdk-driver value 'none'
    This can be used with e.g. mlx4/mlx5 NICs where we don't want to unbind the devices from the kernel
 * ovs-dpdk: support late initialization since ovs 2.6.0
    Enables the new form of initializing OVS with DPDK in the newer versions
 * Add bond-mappings configuration option
    Handle bond creation when DPDK is enabled

The patches are not tested on anything but the unit tests. They need to be run within a real OpenStack deployment and verified against a running OVS.
Should not be considered production ready!